### PR TITLE
Added include directory.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ class egg_install(bdist_egg):
 include_dirs = [
         '/usr/include',
         '/usr/local/include',
+        '/usr/include/udunits2',
         ]
 if 'C_INCLUDE_PATH' in os.environ:
     include_dirs = os.environ['C_INCLUDE_PATH'].split(':') + include_dirs


### PR DESCRIPTION
Just added `/usr/include/udunits2` directory to the `include_dirs` list.  The directory `/usr/include/udunits2` is used in several Linux distros (OpenSUSE and Fedora at least) to avoid collision with the first version of udunits.  By adding this directory to the list you will make the packagers life a lot easier :smile: 
