### PR TITLE
Fix library paths

### DIFF
--- a/udunitspy/udunits2.py
+++ b/udunitspy/udunits2.py
@@ -139,7 +139,7 @@ class System:
 DEFAULT_UDUNITS_PATH = os.path.realpath(os.path.join(sys.prefix, 'etc','udunits','udunits2.xml'))
 if not os.path.exists(DEFAULT_UDUNITS_PATH):
     # Development
-    DEFAULT_UDUNITS_PATH = os.path.realpath(os.path.join(os.path.dirname(__file__), '..','etc','udunits','udunits2.xml'))
+    DEFAULT_UDUNITS_PATH = os.path.realpath(os.path.join(os.path.dirname(__file__), '..','..','..','..','etc','udunits','udunits2.xml'))
 if not os.path.exists(DEFAULT_UDUNITS_PATH):
     # Installed by udunits library
     DEFAULT_UDUNITS_PATH = '/usr/local/share/udunits/udunits2.xml'

--- a/udunitspy/udunits2.py
+++ b/udunitspy/udunits2.py
@@ -142,7 +142,7 @@ if not os.path.exists(DEFAULT_UDUNITS_PATH):
     DEFAULT_UDUNITS_PATH = os.path.realpath(os.path.join(os.path.dirname(__file__), '..','..','..','..','etc','udunits','udunits2.xml'))
 if not os.path.exists(DEFAULT_UDUNITS_PATH):
     # Installed by udunits library
-    DEFAULT_UDUNITS_PATH = '/usr/local/share/udunits/udunits2.xml'
+    DEFAULT_UDUNITS_PATH = '/usr/share/xml/udunits/udunits2.xml'
 
 log.info('Using udunits2.xml database: %s', DEFAULT_UDUNITS_PATH)
 DEFAULT_SYSTEM = System(path=DEFAULT_UDUNITS_PATH)


### PR DESCRIPTION
Installing `udunits` via `pip install --user udunitspy` completes successfully, but it cannot find the `udunits2.xml` database:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/nathaniel/.local/lib/python2.7/site-packages/udunitspy/__init__.py", line 1, in <module>
    from udunits2 import Unit, System, Converter, UdunitsError
  File "/home/nathaniel/.local/lib/python2.7/site-packages/udunitspy/udunits2.py", line 148, in <module>
    DEFAULT_SYSTEM = System(path=DEFAULT_UDUNITS_PATH)
  File "/home/nathaniel/.local/lib/python2.7/site-packages/udunitspy/udunits2.py", line 86, in __init__
    raise UdunitsError(System.__init__.__name__, ut.get_status())
udunitspy.udunits2.UdunitsError: __init__ resulted in udunits error UT_OPEN_ARG:  Can't open argument-specified unit database
```

This fixes the problem.
